### PR TITLE
Update route.yaml to include TLS support for Instruqt content

### DIFF
--- a/k8s/route.yaml
+++ b/k8s/route.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   port:
     targetPort: 8080-tcp
+  tls: 
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge    
   to:
     kind: Service
     name: pipelines-vote-ui

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
         </div>
       </div>
     </div>
-    <script src="http://code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
+    <script src="//code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.js"></script>
 
     {% if vote %}


### PR DESCRIPTION
Instruqt is switching over to https routes.  This change should help fix the example code for instruqt users